### PR TITLE
Fix image gallery load lag

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -61,11 +61,9 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen> {
     // Read the image path map from the JSON file (simulating a separate storage location)
     List<ContactEntry> loadedImages = [];
 
-    // TODO: revisit this logicand whether it can be simplified
-    // specifically, whether there's a way to remove the redundancy of creating a map
-    // and then using the results of that map to essentially create a second map with `get()`
-    for (final entry in (await StorageUtils.toMap()).entries) {
-      final identifier = entry.key;
+    // Fetch each contact directly from Hive using the keys list to avoid
+    // reading the entire box twice.
+    for (final identifier in StorageUtils.getKeys()) {
       final contactEntry = await StorageUtils.get(identifier);
       if (contactEntry != null) {
         loadedImages.add(contactEntry);

--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -295,6 +295,12 @@ class StorageUtils {
     return ret;
   }
 
+  /// Returns all keys from the contacts Hive box without fetching values.
+  static List<String> getKeys() {
+    final box = Hive.box('contacts');
+    return box.keys.whereType<String>().toList();
+  }
+
   /// Get size of Contacts box
   static int getSize() {
     final box = Hive.box('contacts');


### PR DESCRIPTION
## Summary
- avoid retrieving Hive entries twice during gallery load
- expose a helper to list keys in Hive box for faster iteration

## Testing
- `flutter test` *(fails: Box not found. Did you forget to call Hive.openBox?)*

------
https://chatgpt.com/codex/tasks/task_e_684e0b6cfd94832db4a3b2a26a0f9bec