### PR TITLE
Add username editing in tile

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -522,7 +522,7 @@ class ImageGallery extends StatelessWidget {
 }
 
 // Updated ImageTile Widget with Selection
-class ImageTile extends StatelessWidget {
+class ImageTile extends StatefulWidget {
   final String imagePath;
   final bool isSelected;
   final String extractedText;
@@ -543,31 +543,37 @@ class ImageTile extends StatelessWidget {
     required this.contact,
   });
 
+  @override
+  _ImageTileState createState() => _ImageTileState();
+}
+
+class _ImageTileState extends State<ImageTile> {
+
   String get _truncatedText {
     const maxChars = 120;
-    if (extractedText.length <= maxChars) return extractedText;
-    return '${extractedText.substring(0, maxChars)}...';
+    if (widget.extractedText.length <= maxChars) return widget.extractedText;
+    return '${widget.extractedText.substring(0, maxChars)}...';
   }
 
   String get _displayLabel {
-    if (sortOption == 'Date') {
-      return DateFormat.yMd().format(contact.dateFound);
+    if (widget.sortOption == 'Date') {
+      return DateFormat.yMd().format(widget.contact.dateFound);
     }
-    return identifier;
+    return widget.identifier;
   }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () => _showDetailsDialog(context),
-      onLongPress: () => onSelected(identifier),
+      onLongPress: () => widget.onSelected(widget.identifier),
       child: LayoutBuilder(builder: (context, constraints) {
         return Container(
           margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           width: constraints.maxWidth * 0.8,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(16),
-            border: isSelected
+            border: widget.isSelected
                 ? Border.all(color: Colors.blueAccent, width: 3)
                 : null,
             boxShadow: const [
@@ -584,7 +590,7 @@ class ImageTile extends StatelessWidget {
               children: [
                 Positioned.fill(
                   child: PhotoView(
-                    imageProvider: FileImage(File(imagePath)),
+                    imageProvider: FileImage(File(widget.imagePath)),
                     backgroundDecoration:
                         const BoxDecoration(color: Colors.white),
                     minScale: PhotoViewComputedScale.contained,
@@ -621,12 +627,12 @@ class ImageTile extends StatelessWidget {
                       ),
                       const SizedBox(height: 4),
                       GestureDetector(
-                        onTap: () => onSelected(identifier),
+                        onTap: () => widget.onSelected(widget.identifier),
                         child: Icon(
-                          isSelected
+                          widget.isSelected
                               ? Icons.check_circle
                               : Icons.radio_button_unchecked,
-                          color: isSelected ? Colors.blueAccent : Colors.grey,
+                          color: widget.isSelected ? Colors.blueAccent : Colors.grey,
                           size: 28,
                         ),
                       ),
@@ -657,7 +663,7 @@ class ImageTile extends StatelessWidget {
                             style: const TextStyle(color: Colors.white),
                           ),
                         ),
-                        if (contact.snapUsername?.isNotEmpty ?? false)
+                        if (widget.contact.snapUsername?.isNotEmpty ?? false)
                           IconButton(
                             iconSize: 22,
                             color: Colors.white,
@@ -665,10 +671,10 @@ class ImageTile extends StatelessWidget {
                             constraints: const BoxConstraints.tightFor(
                                 width: 36, height: 36),
                             onPressed: () => _openSocial(
-                                SocialType.Snapchat, contact.snapUsername!),
+                                SocialType.Snapchat, widget.contact.snapUsername!),
                             icon: SocialIcon.snapchatIconButton!.socialIcon,
                           ),
-                        if (contact.instaUsername?.isNotEmpty ?? false)
+                        if (widget.contact.instaUsername?.isNotEmpty ?? false)
                           IconButton(
                             iconSize: 22,
                             color: Colors.white,
@@ -676,10 +682,10 @@ class ImageTile extends StatelessWidget {
                             constraints: const BoxConstraints.tightFor(
                                 width: 36, height: 36),
                             onPressed: () => _openSocial(
-                                SocialType.Instagram, contact.instaUsername!),
+                                SocialType.Instagram, widget.contact.instaUsername!),
                             icon: SocialIcon.instagramIconButton!.socialIcon,
                           ),
-                        if (contact.discordUsername?.isNotEmpty ?? false)
+                        if (widget.contact.discordUsername?.isNotEmpty ?? false)
                           IconButton(
                             iconSize: 22,
                             color: Colors.white,
@@ -687,7 +693,7 @@ class ImageTile extends StatelessWidget {
                             constraints: const BoxConstraints.tightFor(
                                 width: 36, height: 36),
                             onPressed: () => _openSocial(
-                                SocialType.Discord, contact.discordUsername!),
+                                SocialType.Discord, widget.contact.discordUsername!),
                             icon: SocialIcon.discordIconButton!.socialIcon,
                           ),
                         IconButton(
@@ -699,8 +705,8 @@ class ImageTile extends StatelessWidget {
                           icon: const Icon(Icons.note_alt_outlined),
                           onPressed: () async {
                             await showNoteDialog(
-                                context, contact.identifier, contact,
-                                existingNotes: contact.notes);
+                                context, widget.contact.identifier, widget.contact,
+                                existingNotes: widget.contact.notes);
                           },
                         ),
                         IconButton(
@@ -709,8 +715,17 @@ class ImageTile extends StatelessWidget {
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints.tightFor(
                               width: 36, height: 36),
+                          icon: const Icon(Icons.edit),
+                          onPressed: () => _editUsernames(context),
+                        ),
+                        IconButton(
+                          iconSize: 22,
+                          color: Colors.white,
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints.tightFor(
+                              width: 36, height: 36),
                           icon: const Icon(Icons.more_vert),
-                          onPressed: () => _showPopupMenu(context, imagePath),
+                          onPressed: () => _showPopupMenu(context, widget.imagePath),
                         ),
                       ],
                     ),
@@ -739,61 +754,61 @@ class ImageTile extends StatelessWidget {
                 _showDetailsDialog(context);
               },
             ),
-            if (contact.snapUsername?.isNotEmpty ?? false)
+            if (widget.contact.snapUsername?.isNotEmpty ?? false)
               ListTile(
                 leading: Icon(Icons.chat_bubble),
                 title: Text('Open on Snap'),
                 onTap: () {
                   Navigator.pop(sheetContext);
-                  _openSocial(SocialType.Snapchat, contact.snapUsername!);
+                  _openSocial(SocialType.Snapchat, widget.contact.snapUsername!);
                 },
               ),
-            if (contact.instaUsername?.isNotEmpty ?? false)
+            if (widget.contact.instaUsername?.isNotEmpty ?? false)
               ListTile(
                 leading: Icon(Icons.camera_alt),
                 title: Text('Open on Insta'),
                 onTap: () {
                   Navigator.pop(sheetContext);
-                  _openSocial(SocialType.Instagram, contact.instaUsername!);
+                  _openSocial(SocialType.Instagram, widget.contact.instaUsername!);
                 },
               ),
-            if (contact.discordUsername?.isNotEmpty ?? false)
+            if (widget.contact.discordUsername?.isNotEmpty ?? false)
               ListTile(
                 leading: Icon(Icons.discord),
                 title: Text('Open on Discord'),
                 onTap: () {
                   Navigator.pop(sheetContext);
-                  _openSocial(SocialType.Discord, contact.discordUsername!);
+                  _openSocial(SocialType.Discord, widget.contact.discordUsername!);
                 },
               ),
-            if (contact.addedOnSnap)
+            if (widget.contact.addedOnSnap)
               ListTile(
                 leading: Icon(Icons.refresh),
                 title: Text('Mark Snap Unadded'),
                 onTap: () async {
                   Navigator.pop(sheetContext);
                   bool res = await _confirm(context);
-                  if (res) contact.resetSnapchatAdd();
+                  if (res) widget.contact.resetSnapchatAdd();
                 },
               ),
-            if (contact.addedOnInsta)
+            if (widget.contact.addedOnInsta)
               ListTile(
                 leading: Icon(Icons.refresh),
                 title: Text('Mark Insta Unadded'),
                 onTap: () async {
                   Navigator.pop(sheetContext);
                   bool res = await _confirm(context);
-                  if (res) contact.resetInstagramAdd();
+                  if (res) widget.contact.resetInstagramAdd();
                 },
               ),
-            if (contact.addedOnDiscord)
+            if (widget.contact.addedOnDiscord)
               ListTile(
                 leading: Icon(Icons.refresh),
                 title: Text('Mark Discord Unadded'),
                 onTap: () async {
                   Navigator.pop(sheetContext);
                   bool res = await _confirm(context);
-                  if (res) contact.resetDiscordAdd();
+                  if (res) widget.contact.resetDiscordAdd();
                 },
               ),
             ListTile(
@@ -801,15 +816,15 @@ class ImageTile extends StatelessWidget {
               title: Text('Edit Notes'),
               onTap: () async {
                 Navigator.pop(sheetContext);
-                await showNoteDialog(context, contact.identifier, contact,
-                    existingNotes: contact.notes);
+                await showNoteDialog(context, widget.contact.identifier, widget.contact,
+                    existingNotes: widget.contact.notes);
               },
             ),
             ListTile(
               leading: Icon(Icons.move_to_inbox),
               title: Text('Move'),
               onTap: () {
-                onMenuOptionSelected(imagePath, 'move');
+                widget.onMenuOptionSelected(imagePath, 'move');
                 Navigator.pop(sheetContext);
               },
             ),
@@ -829,7 +844,7 @@ class ImageTile extends StatelessWidget {
             Container(
               constraints: BoxConstraints(maxHeight: 300),
               child: PhotoView(
-                imageProvider: FileImage(File(imagePath)),
+                imageProvider: FileImage(File(widget.imagePath)),
                 backgroundDecoration: BoxDecoration(color: Colors.white),
                 minScale: PhotoViewComputedScale.contained,
                 maxScale: PhotoViewComputedScale.covered * 2.5,
@@ -838,7 +853,7 @@ class ImageTile extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(12.0),
               child: Text(
-                extractedText.isNotEmpty ? extractedText : 'No text found',
+                widget.extractedText.isNotEmpty ? widget.extractedText : 'No text found',
               ),
             ),
             TextButton(
@@ -857,6 +872,64 @@ class ImageTile extends StatelessWidget {
       builder: (_) => ConfirmationDialog(message: 'Are you sure?'),
     );
     return result ?? false;
+  }
+
+  Future<void> _editUsernames(BuildContext context) async {
+    final snapController = TextEditingController(text: widget.contact.snapUsername ?? '');
+    final instaController = TextEditingController(text: widget.contact.instaUsername ?? '');
+    final discordController = TextEditingController(text: widget.contact.discordUsername ?? '');
+
+    final result = await showDialog<List<String>>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Edit Usernames'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: snapController,
+                decoration: InputDecoration(labelText: 'Snapchat'),
+              ),
+              TextField(
+                controller: instaController,
+                decoration: InputDecoration(labelText: 'Instagram'),
+              ),
+              TextField(
+                controller: discordController,
+                decoration: InputDecoration(labelText: 'Discord'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(
+                context,
+                [snapController.text, instaController.text, discordController.text],
+              ),
+              child: Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result != null) {
+      if (result[0] != widget.contact.snapUsername) {
+        await SocialType.Snapchat.saveUsername(widget.contact, result[0], overriding: true);
+      }
+      if (result[1] != widget.contact.instaUsername) {
+        await SocialType.Instagram.saveUsername(widget.contact, result[1], overriding: true);
+      }
+      if (result[2] != widget.contact.discordUsername) {
+        await SocialType.Discord.saveUsername(widget.contact, result[2], overriding: true);
+      }
+      setState(() {});
+    }
   }
 
   void _openSocial(SocialType social, String username) async {

--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -866,54 +866,91 @@ class _ImageTileState extends State<ImageTile> {
     );
   }
 
-  Future<bool> _confirm(BuildContext context) async {
+  Future<bool> _confirm(BuildContext context, {String message = 'Are you sure?'}) async {
     final result = await showDialog<bool>(
       context: context,
-      builder: (_) => ConfirmationDialog(message: 'Are you sure?'),
+      builder: (_) => ConfirmationDialog(message: message),
     );
     return result ?? false;
   }
 
   Future<void> _editUsernames(BuildContext context) async {
-    final snapController = TextEditingController(text: widget.contact.snapUsername ?? '');
-    final instaController = TextEditingController(text: widget.contact.instaUsername ?? '');
-    final discordController = TextEditingController(text: widget.contact.discordUsername ?? '');
+    final originalSnap = widget.contact.snapUsername ?? '';
+    final originalInsta = widget.contact.instaUsername ?? '';
+    final originalDiscord = widget.contact.discordUsername ?? '';
+
+    final snapController = TextEditingController(text: originalSnap);
+    final instaController = TextEditingController(text: originalInsta);
+    final discordController = TextEditingController(text: originalDiscord);
+
+    bool changed = false;
+    void updateChanged() {
+      changed = snapController.text != originalSnap ||
+          instaController.text != originalInsta ||
+          discordController.text != originalDiscord;
+    }
+
+    snapController.addListener(updateChanged);
+    instaController.addListener(updateChanged);
+    discordController.addListener(updateChanged);
 
     final result = await showDialog<List<String>>(
       context: context,
+      barrierDismissible: false,
       builder: (context) {
-        return AlertDialog(
-          title: Text('Edit Usernames'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: snapController,
-                decoration: InputDecoration(labelText: 'Snapchat'),
+        return WillPopScope(
+          onWillPop: () async {
+            if (changed) {
+              return await _confirm(context, message: 'Discard changes?');
+            }
+            return true;
+          },
+          child: AlertDialog(
+            title: Text('Edit Usernames'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: snapController,
+                  decoration: InputDecoration(labelText: 'Snapchat'),
+                ),
+                TextField(
+                  controller: instaController,
+                  decoration: InputDecoration(labelText: 'Instagram'),
+                ),
+                TextField(
+                  controller: discordController,
+                  decoration: InputDecoration(labelText: 'Discord'),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () async {
+                  if (changed) {
+                    final discard = await _confirm(context, message: 'Discard changes?');
+                    if (!discard) return;
+                  }
+                  Navigator.pop(context);
+                },
+                child: Text('Cancel'),
               ),
-              TextField(
-                controller: instaController,
-                decoration: InputDecoration(labelText: 'Instagram'),
-              ),
-              TextField(
-                controller: discordController,
-                decoration: InputDecoration(labelText: 'Discord'),
+              TextButton(
+                onPressed: () async {
+                  if (changed) {
+                    final confirmSave = await _confirm(context, message: 'Save changes?');
+                    if (!confirmSave) return;
+                  }
+                  Navigator.pop(context, [
+                    snapController.text,
+                    instaController.text,
+                    discordController.text,
+                  ]);
+                },
+                child: Text('Save'),
               ),
             ],
           ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(
-                context,
-                [snapController.text, instaController.text, discordController.text],
-              ),
-              child: Text('Save'),
-            ),
-          ],
         );
       },
     );

--- a/lib/models/contactEntry.dart
+++ b/lib/models/contactEntry.dart
@@ -333,30 +333,30 @@ abstract class _ContactEntry with Store {
   @action
   updateSnapchat(String snapchat) {
     _suppressAutoSave = false;
-    if (snapUsername != null) {
-      previousHandles?[SubKeys.SnapUsername]?.add(snapchat);
-      snapUsername = snapchat;
+    if (snapUsername != null && snapUsername!.isNotEmpty) {
+      previousHandles?[SubKeys.SnapUsername]?.add(snapUsername!);
     }
+    snapUsername = snapchat;
     _suppressAutoSave = true;
   }
 
   @action
   updateInstagram(String instagram) {
     _suppressAutoSave = false;
-    if (instaUsername != null) {
-      previousHandles?[SubKeys.InstaUsername]?.add(instagram);
-      instaUsername = instagram;
+    if (instaUsername != null && instaUsername!.isNotEmpty) {
+      previousHandles?[SubKeys.InstaUsername]?.add(instaUsername!);
     }
+    instaUsername = instagram;
     _suppressAutoSave = true;
   }
 
   @action
   updateDiscord(String discord) {
     _suppressAutoSave = false;
-    if (discordUsername != null) {
-      previousHandles?[SubKeys.DiscordUsername]?.add(discord);
-      discordUsername = discord;
+    if (discordUsername != null && discordUsername!.isNotEmpty) {
+      previousHandles?[SubKeys.DiscordUsername]?.add(discordUsername!);
     }
+    discordUsername = discord;
     _suppressAutoSave = true;
   }
 

--- a/lib/social_icons.dart
+++ b/lib/social_icons.dart
@@ -113,13 +113,25 @@ extension SocialTypeExtension on SocialType{
   saveUsername(ContactEntry entry, String value, {required bool overriding}) async {
     switch (this) {
       case SocialType.Snapchat:
-        entry.snapUsername = value;
+        if (overriding) {
+          entry.updateSnapchat(value);
+        } else {
+          entry.snapUsername = value;
+        }
         break;
       case SocialType.Instagram:
-        entry.instaUsername = value;
+        if (overriding) {
+          entry.updateInstagram(value);
+        } else {
+          entry.instaUsername = value;
+        }
         break;
       case SocialType.Discord:
-        entry.discordUsername = value;
+        if (overriding) {
+          entry.updateDiscord(value);
+        } else {
+          entry.discordUsername = value;
+        }
         break;
       case SocialType.Kik:
       // return SocialIcon.kikIconButton.socialIcon;


### PR DESCRIPTION
## Summary
- allow model update functions to track previous usernames
- adjust `saveUsername` to use update methods when overriding
- convert `ImageTile` to `StatefulWidget` and embed an edit button for usernames
- implement dialog to edit usernames directly in the tile

## Testing
- `flutter analyze`
- `flutter test` *(fails: unhandled error)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ddb1694832db294eb8a7de8115e