### PR TITLE
Remove duplicate image index info

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -161,9 +161,6 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
                   currentIndex: currentIndex,
                 ),
               ),
-              const SizedBox(height: 8),
-              Text(
-                  'Image ${images.isEmpty ? 0 : currentIndex + 1} of ${images.length}'),
             ],
           );
         }),


### PR DESCRIPTION
## Summary
- trim unneeded `Image n of m` text in `ImageGalleryScreen`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684f46b55f88832da114d6b18e60db92