### PR TITLE
Begin migrating to extended_image

### DIFF
--- a/lib/experimental/1attempt/test_new_gallery.dart
+++ b/lib/experimental/1attempt/test_new_gallery.dart
@@ -1,6 +1,6 @@
 import 'package:PhotoWordFind/gallery/gallery_cell.dart';
 import 'package:flutter/material.dart';
-import 'package:photo_view/photo_view.dart';
+import 'package:extended_image/extended_image.dart';
 
 import 'package:PhotoWordFind/main.dart';
 
@@ -32,11 +32,17 @@ class ImageListScreen extends StatelessWidget {
           Container(
             width: 200, // Set the width for each image card
             height: 200, // Set height for the image display
-            child: PhotoView(
-              imageProvider:
-                  AssetImage(imagewidget.srcImage.path),
-              minScale: PhotoViewComputedScale.contained * 0.8,
-              maxScale: PhotoViewComputedScale.covered * 2,
+            child: ExtendedImage(
+              image: AssetImage(imagewidget.srcImage.path),
+              mode: ExtendedImageMode.gesture,
+              initGestureConfigHandler: (state) {
+                return GestureConfig(
+                  minScale: 0.8,
+                  maxScale: 2,
+                  initialScale: 0.8,
+                  inPageView: false,
+                );
+              },
             ),
           ),
           SizedBox(height: 10), // Space between image and text

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
 
   # Photo gallery functionality
   photo_view: ^0.14.0
+  extended_image: ^8.1.0
 
   # For little faded notification on screen
   fluttertoast: ^8.0.8


### PR DESCRIPTION
## Summary
- add extended_image dependency
- update experimental gallery widgets to use extended_image

## Testing
- `flutter test test/image_gallery_test.dart -r expanded` *(fails: Resolving dependencies... due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_6858cad5be58832db4ec21a49d070570