### PR TITLE
Add network rules for Flutter tools

### DIFF
--- a/.codex/network.yaml
+++ b/.codex/network.yaml
@@ -1,0 +1,5 @@
+allow:
+  # pub.dev metadata + package tarballs
+  - GET https://pub.dev/**
+  # Flutter tool downloads and some package mirrors
+  - GET https://storage.googleapis.com/**


### PR DESCRIPTION
## Summary
- allow access to pub.dev and Google storage for Flutter tools in `.codex/network.yaml`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_685cf846b0b4832d8d6a2f7af87c8824