### PR TITLE
Fix asset picker not showing in English

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -561,7 +561,10 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
     } else {
       assets = await AssetPicker.pickAssets(
         pickerContext,
-        pickerConfig: const AssetPickerConfig(requestType: RequestType.image),
+        pickerConfig: const AssetPickerConfig(
+          requestType: RequestType.image,
+          textDelegate: EnglishAssetPickerTextDelegate(),
+        ),
       );
     }
     if (assets == null || assets.isEmpty) {
@@ -658,6 +661,7 @@ class _ImportDelegate extends DefaultAssetPickerBuilderDelegate {
       : super(
           provider: provider,
           initialPermission: permission,
+          textDelegate: const EnglishAssetPickerTextDelegate(),
         );
 
   final _ImportProvider provider;


### PR DESCRIPTION
## Summary
- enforce English localization for asset picker

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6860fbdc36e0832db06c5c10712a892a