### PR TITLE
Add settings page with import directory reset

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -148,6 +148,7 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
                       MaterialPageRoute(
                         builder: (_) => SettingsScreen(
                           onResetImportDir: _resetImportDir,
+                          onChangeImportDir: _changeImportDir,
                         ),
                       ),
                     );
@@ -456,8 +457,7 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
 
   Future<void> _loadImportDirectory() async {
     final prefs = await SharedPreferences.getInstance();
-    _importDirPath =
-        prefs.getString(_importDirKey) ?? '/storage/emulated/0/DCIM';
+    _importDirPath = prefs.getString(_importDirKey);
   }
 
   Future<void> _saveImportDirectory(String path) async {
@@ -479,7 +479,7 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_importDirKey);
     setState(() {
-      _importDirPath = '/storage/emulated/0/DCIM';
+      _importDirPath = null;
     });
   }
 

--- a/lib/experimental/2attempt/settings_screen.dart
+++ b/lib/experimental/2attempt/settings_screen.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 
 class SettingsScreen extends StatelessWidget {
   final Future<void> Function() onResetImportDir;
+  final Future<void> Function() onChangeImportDir;
 
-  const SettingsScreen({Key? key, required this.onResetImportDir})
-      : super(key: key);
+  const SettingsScreen({
+    Key? key,
+    required this.onResetImportDir,
+    required this.onChangeImportDir,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -13,9 +17,17 @@ class SettingsScreen extends StatelessWidget {
       body: ListView(
         children: [
           ListTile(
+            leading: const Icon(Icons.folder_open),
+            title: const Text('Change Import Directory'),
+            subtitle: const Text('Select a new directory for imports'),
+            onTap: () async {
+              await onChangeImportDir();
+            },
+          ),
+          ListTile(
             leading: const Icon(Icons.restore),
             title: const Text('Reset Import Directory'),
-            subtitle: const Text('Set import directory back to default'),
+            subtitle: const Text('Clear saved import directory'),
             onTap: () async {
               await onResetImportDir();
               if (context.mounted) {


### PR DESCRIPTION
## Summary
- add a SettingsScreen for future options
- add gear icon in the new UI app bar
- allow resetting the import directory to default

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686207ca4be8832da2ec6bc2964faf8b