### PR TITLE
Fix JDK path configuration for bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ powershell -ExecutionPolicy Bypass -File ./scripts/bootstrap.ps1
 The script installs Eclipse Temurin JDK 17 and Android Studio via `winget`,
 refreshing the current `PATH` after each installation so new commands are
 available immediately. The JDK location is persisted in `PWF_JAVA_HOME` and
-prepended to your user `PATH` without affecting other JDK versions. Every
+prepended to your user `PATH` without affecting other JDK versions. The
+path is also written to `android/gradle.properties` as `org.gradle.java.home`
+so Gradle can locate the JDK automatically. Every
 Firebase CLI command includes `--project=pwfapp-f314d`, so no `firebase use`
 state is required. It prints progress messages for each step—including when
 downloading the keystore, parsing the Firebase Functions config value and

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
-# org.gradle.java.home=C\:\\Users\\deziu\\.jdks\\corretto-11.0.18
+

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -82,6 +82,24 @@ if ($jdkDir) {
     if ($env:Path -notlike "$jdkPathEntry*") {
         $env:Path = "$jdkPathEntry;" + $env:Path
     }
+
+    $gradleProps = Join-Path $PSScriptRoot "..\android\gradle.properties"
+    if (Test-Path $gradleProps) {
+        $props = Get-Content $gradleProps
+        $newLine = "org.gradle.java.home=$env:PWF_JAVA_HOME"
+        $updated = $false
+        $props = $props | ForEach-Object {
+            if ($_ -match '^\s*#?\s*org\.gradle\.java\.home=') {
+                $updated = $true
+                $newLine
+            } else {
+                $_
+            }
+        }
+        if (-not $updated) { $props += $newLine }
+        Set-Content $gradleProps $props
+        Write-Host "Set org.gradle.java.home in gradle.properties" -ForegroundColor Green
+    }
 }
 
 # Install Firebase CLI if missing


### PR DESCRIPTION
## Summary
- remove hard-coded `org.gradle.java.home`
- update Windows bootstrap script to write the JDK path into `gradle.properties`
- document new behaviour in README

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_687dae22bf8c832db26ee084692ca929