### PR TITLE
Install Android platform-tools during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ powershell -ExecutionPolicy Bypass -File ./scripts/bootstrap.ps1
 
 The script installs Eclipse Temurin JDK 17 and Android Studio via `winget`,
 refreshing the current `PATH` after each installation so new commands are
-available immediately. The JDK location is persisted in `PWF_JAVA_HOME` and
+available immediately. Android platform-tools are installed as well so `adb`
+works without extra steps. The JDK location is persisted in `PWF_JAVA_HOME` and
 prepended to your user `PATH` without affecting other JDK versions. The
 path is also written to `android/gradle.properties` as `org.gradle.java.home`
 so Gradle can locate the JDK automatically. Every

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -57,7 +57,7 @@ if (-not (Test-Path $sdkManager)) {
 }
 if (Test-Path $sdkManager) {
     Write-Host "Ensuring Android cmdline tools installed..."
-    & $sdkManager --install "cmdline-tools;latest" | Out-Null
+    & $sdkManager --install "cmdline-tools;latest" "platform-tools" | Out-Null
 }
 
 $jdkDir = Get-ChildItem "$Env:ProgramFiles\Eclipse Adoptium" -Directory -Filter 'jdk-17*' | Sort-Object Name -Descending | Select-Object -First 1
@@ -99,6 +99,18 @@ if ($jdkDir) {
         if (-not $updated) { $props += $newLine }
         Set-Content $gradleProps $props
         Write-Host "Set org.gradle.java.home in gradle.properties" -ForegroundColor Green
+    }
+}
+
+$adbPathEntry = "$Env:LOCALAPPDATA\Android\Sdk\platform-tools"
+if (Test-Path $adbPathEntry) {
+    $persistPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not ($persistPath -split ';' | Where-Object { $_ -eq $adbPathEntry })) {
+        Write-Host "Adding Android platform-tools to user PATH..."
+        setx Path "$adbPathEntry;" + $persistPath | Out-Null
+    }
+    if ($env:Path -notlike "$adbPathEntry*") {
+        $env:Path = "$adbPathEntry;" + $env:Path
     }
 }
 


### PR DESCRIPTION
## Summary
- install `platform-tools` with `sdkmanager`
- add platform-tools directory to PATH in the bootstrap script
- document automatic ADB installation in README

## Testing
- `dart format -o write .`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_687f1123bb30832d8073a7240b9aa651