### PR TITLE
Improve bootstrap reliability

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -19,15 +19,24 @@ function Refresh-SessionPath {
     $env:Path    = "$machinePath;$userPath"
 }
 
+# Returns $true when the given winget package id is installed
+function Is-WingetPackageInstalled($id) {
+    $out = winget list --id $id -e 2>$null
+    return ($LASTEXITCODE -eq 0 -and $out -and $out -notmatch 'No installed')
+}
+
 # Ensure JDK 17 is installed and available
 $jdkPackage = 'EclipseAdoptium.Temurin.17.JDK'
+if (-not (Is-WingetPackageInstalled $jdkPackage)) {
+    Write-Host "Installing JDK 17 via winget..."
+    winget install -e --id $jdkPackage
+    Refresh-SessionPath
+} else {
+    Write-Host "JDK package already installed." -ForegroundColor Green
+}
+# Check if installed JDK is version 17
 $needJdk = $true
 $verCheck = Get-Command java -ErrorAction SilentlyContinue
-if ($verCheck) {
-    Write-Host "Existing Java detected: $($verCheck.Source)"
-} else {
-    Write-Host "No Java installation detected in PATH."
-}
 if ($verCheck) {
     $verLine = (& java -version 2>&1)[0]
     if ($verLine -match '"(\d+)"') {
@@ -35,30 +44,54 @@ if ($verCheck) {
     }
 }
 if ($needJdk) {
-    Write-Host "Installing JDK 17 via winget..."
-    winget install -e --id $jdkPackage
-    Refresh-SessionPath
-} else {
-    Write-Host "Compatible JDK already present." -ForegroundColor Green
+    Write-Host "Warning: JAVA_HOME not set to JDK 17" -ForegroundColor Yellow
 }
 
 # Ensure Android Studio and command line tools are installed
-if (-not (Get-Command studio64.exe -ErrorAction SilentlyContinue)) {
+$studioPackage = 'Google.AndroidStudio'
+if (-not (Is-WingetPackageInstalled $studioPackage)) {
     Write-Host "Installing Android Studio via winget..."
-    winget install -e --id Google.AndroidStudio
+    winget install -e --id $studioPackage
     Refresh-SessionPath
 } else {
     Write-Host "Android Studio already installed." -ForegroundColor Green
+}
+# Guarantee studio64.exe is reachable from PATH
+$studioCmd = Get-Command studio64.exe -ErrorAction SilentlyContinue
+if (-not $studioCmd) {
+    $searchDirs = @(
+        "$env:LOCALAPPDATA\Programs\Android\Android Studio\bin",
+        "$env:ProgramFiles\Android\Android Studio\bin",
+        "$env:ProgramFiles\Google\Android Studio\bin"
+    )
+    foreach ($d in $searchDirs) {
+        $candidate = Join-Path $d 'studio64.exe'
+        if (Test-Path $candidate) { $studioCmd = @{ Source = $candidate }; break }
+    }
+}
+if ($studioCmd) {
+    $studioDir = Split-Path $studioCmd.Source
+    $persistPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not ($persistPath -split ';' | Where-Object { $_ -eq $studioDir })) {
+        Write-Host "Adding Android Studio to user PATH..."
+        setx Path "$studioDir;" + $persistPath | Out-Null
+    }
+    if ($env:Path -notlike "$studioDir*") { $env:Path = "$studioDir;" + $env:Path }
+} else {
+    Write-Host "Android Studio executable not found" -ForegroundColor Yellow
 }
 
 $sdkManager = "$Env:LOCALAPPDATA\Android\Sdk\cmdline-tools\latest\bin\sdkmanager.bat"
 if (-not (Test-Path $sdkManager)) {
     $sdkManager = "$Env:LOCALAPPDATA\Android\Sdk\tools\bin\sdkmanager.bat"
 }
+$needStudioSetup = $false
 if (Test-Path $sdkManager) {
-    Write-Host "Ensuring Android cmdline tools installed..."
-    & $sdkManager --install "cmdline-tools;latest" "platform-tools" | Out-Null
+    Write-Host "Found Android cmdline tools." -ForegroundColor Green
+} else {
+    $needStudioSetup = $true
 }
+$studioProcess = $null
 
 $jdkDir = Get-ChildItem "$Env:ProgramFiles\Eclipse Adoptium" -Directory -Filter 'jdk-17*' | Sort-Object Name -Descending | Select-Object -First 1
 if ($jdkDir) {
@@ -83,24 +116,26 @@ if ($jdkDir) {
         $env:Path = "$jdkPathEntry;" + $env:Path
     }
 
-    $gradleProps = Join-Path $PSScriptRoot "..\android\gradle.properties"
-    if (Test-Path $gradleProps) {
-        $props = Get-Content $gradleProps
-        $newLine = "org.gradle.java.home=$env:PWF_JAVA_HOME"
-        $updated = $false
-        $props = $props | ForEach-Object {
-            if ($_ -match '^\s*#?\s*org\.gradle\.java\.home=') {
-                $updated = $true
-                $newLine
-            } else {
-                $_
-            }
-        }
-        if (-not $updated) { $props += $newLine }
-        Set-Content $gradleProps $props
-        Write-Host "Set org.gradle.java.home in gradle.properties" -ForegroundColor Green
-    }
 }
+    $gradleHome = $env:GRADLE_USER_HOME
+    if (-not $gradleHome) { $gradleHome = Join-Path $Env:USERPROFILE '.gradle' }
+    if (-not (Test-Path $gradleHome)) { New-Item -ItemType Directory -Path $gradleHome | Out-Null }
+    $gradleProps = Join-Path $gradleHome 'gradle.properties'
+    $props = @()
+    if (Test-Path $gradleProps) { $props = Get-Content $gradleProps }
+    $newLine = "org.gradle.java.home=$env:PWF_JAVA_HOME"
+    $updated = $false
+    $props = $props | ForEach-Object {
+        if ($_ -match '^\s*#?\s*org\.gradle\.java\.home=') {
+            $updated = $true
+            $newLine
+        } else {
+            $_
+        }
+    }
+    if (-not $updated) { $props += $newLine }
+    Set-Content $gradleProps $props
+    Write-Host "Set org.gradle.java.home in user gradle.properties" -ForegroundColor Green
 
 $adbPathEntry = "$Env:LOCALAPPDATA\Android\Sdk\platform-tools"
 if (Test-Path $adbPathEntry) {
@@ -114,16 +149,61 @@ if (Test-Path $adbPathEntry) {
     }
 }
 
+# Ensure Flutter is installed and on PATH
+$flutterPackage = 'Flutter.Flutter'
+if (-not (Is-WingetPackageInstalled $flutterPackage)) {
+    Write-Host "Installing Flutter via winget..."
+    winget install -e --id $flutterPackage
+    Refresh-SessionPath
+} else {
+    Write-Host "Flutter already installed." -ForegroundColor Green
+}
+$flutterCmd = Get-Command flutter -ErrorAction SilentlyContinue
+if (-not $flutterCmd) {
+    $searchDirs = @(
+        "$env:LOCALAPPDATA\Programs\flutter\bin",
+        "$env:ProgramFiles\flutter\bin",
+        "$env:ProgramFiles(x86)\flutter\bin"
+    )
+    foreach ($d in $searchDirs) {
+        $candidate = Join-Path $d 'flutter.bat'
+        if (Test-Path $candidate) { $flutterCmd = @{ Source = $candidate }; break }
+    }
+}
+if ($flutterCmd) {
+    $flutterBin = Split-Path $flutterCmd.Source
+    $persistPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not ($persistPath -split ';' | Where-Object { $_ -eq $flutterBin })) {
+        Write-Host "Adding Flutter to user PATH..."
+        setx Path "$flutterBin;" + $persistPath | Out-Null
+    }
+    if ($env:Path -notlike "$flutterBin*") { $env:Path = "$flutterBin;" + $env:Path }
+    Push-Location (Split-Path $flutterBin -Parent)
+    git fetch --tags
+    git checkout 3.24.5
+    Pop-Location
+} else {
+    Write-Host "Flutter executable not found" -ForegroundColor Yellow
+}
+
 # Install Firebase CLI if missing
-if (-not (Get-Command firebase -ErrorAction SilentlyContinue)) {
+$firebasePackage = 'Google.FirebaseCLI'
+if (-not (Is-WingetPackageInstalled $firebasePackage)) {
     Write-Host "Installing Firebase CLI via winget..."
-    winget install -e --id Google.FirebaseCLI
+    winget install -e --id $firebasePackage
     Refresh-SessionPath
 }
 
 # Sign in to Firebase
 Write-Host "Authenticating with Firebase..."
 firebase login
+
+# Launch Android Studio setup wizard if cmdline tools are missing
+if ($needStudioSetup -and $studioCmd) {
+    Write-Host "Starting Android Studio to complete SDK setup..."
+    Write-Host "Please finish the wizard while the script continues running."
+    $studioProcess = Start-Process -FilePath $studioCmd.Source -PassThru
+}
 
 # Fetch debug keystore
 $keystorePath = Join-Path $PSScriptRoot "..\android\app\debug.keystore"
@@ -186,6 +266,20 @@ if ($existing -contains $fingerprint) {
         Write-Host "SHA-1 fingerprint registered successfully." -ForegroundColor Green
     } else {
         Write-Host "Failed to register fingerprint." -ForegroundColor Yellow
+    }
+}
+
+# Wait for Android Studio wizard if it was started
+if ($studioProcess) {
+    Write-Host "Waiting for Android Studio setup to finish..."
+    Wait-Process -Id $studioProcess.Id
+    Refresh-SessionPath
+    $sdkManager = "$Env:LOCALAPPDATA\Android\Sdk\cmdline-tools\latest\bin\sdkmanager.bat"
+    if (Test-Path $sdkManager) {
+        Write-Host "Installing Android cmdline tools..."
+        & $sdkManager --install "cmdline-tools;latest" "platform-tools" | Out-Null
+    } else {
+        Write-Host "SDK manager still not found" -ForegroundColor Yellow
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure Android Studio is in the user PATH after installation
- write the JDK location to the user Gradle properties instead of the repository copy
- launch Android Studio's wizard if sdkmanager is missing and wait for it at the end
- check winget installed packages instead of relying on PATH
- install Flutter via winget and pin to version 3.24.5

## Testing
- `dart format -o none .`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_687f224fedc0832da18f8c9de6ed9e82