### PR TITLE
Fix JDK path link creation without admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ refreshing the current `PATH` after each installation so new commands are
 available immediately. Android platform-tools are installed as well so `adb`
 works without extra steps. The JDK location is persisted in `PWF_JAVA_HOME` and
 prepended to your user `PATH` without affecting other JDK versions. The script
-creates a `.jdk` symlink in the repository root pointing to this path and
+creates a `.jdk` junction in the repository root pointing to this path and
 `android/gradle.properties` always contains `org.gradle.java.home=../.jdk`, so
 Gradle can locate the JDK without modifying the file per-machine. Every
 Firebase CLI command includes `--project=pwfapp-f314d`, so no `firebase use`

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -129,7 +129,10 @@ if ($jdkDir) {
 
     $jdkLink = Join-Path $PSScriptRoot '..\.jdk'
     if (Test-Path $jdkLink) { Remove-Item $jdkLink }
-    New-Item -ItemType SymbolicLink -Path $jdkLink -Target $env:PWF_JAVA_HOME | Out-Null
+    # Use a junction instead of a symbolic link so admin privileges aren't
+    # required. This still allows Gradle to locate the project's JDK without
+    # modifying global paths.
+    New-Item -ItemType Junction -Path $jdkLink -Target $env:PWF_JAVA_HOME | Out-Null
     Write-Host "Linked .jdk -> $env:PWF_JAVA_HOME" -ForegroundColor Green
 } else {
     Write-Warning "Unable to locate a Temurin JDK 17 under $Env:ProgramFiles. Android Studio may not have been run yet."


### PR DESCRIPTION
## Summary
- link `.jdk` using a junction instead of a symbolic link in `bootstrap.ps1`
- mention the junction in README

## Testing
- `dart format -o write .`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6886dbf34ab0832d936b53c7dc437bad