### PR TITLE
Fix Google sign-in order

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -84,6 +84,11 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
     bool signed = await CloudUtils.isSignedin();
     if (!signed) {
       signed = await CloudUtils.firstSignIn();
+      if (!signed) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Google sign-in failed')),
+        );
+      }
     }
     return signed;
   }
@@ -103,7 +108,12 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
   Future<void> _toggleSignInOut() async {
     bool signed = await CloudUtils.isSignedin();
     if (!signed) {
-      await CloudUtils.firstSignIn();
+      signed = await CloudUtils.firstSignIn();
+      if (!signed) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Google sign-in failed')),
+        );
+      }
     } else {
       final confirm = await showDialog<bool>(
         context: context,

--- a/lib/utils/cloud_utils.dart
+++ b/lib/utils/cloud_utils.dart
@@ -121,7 +121,8 @@ class CloudUtils {
   }
 
   static Future<AuthClient?> _getAuthClient() async {
-    handleSignIn();
+    bool signedIn = await handleSignIn();
+    if (!signedIn) return null;
     return await _googleSignIn.authenticatedClient();
   }
 
@@ -190,17 +191,17 @@ class CloudUtils {
       List<ContactEntry> images = [];
       List<String> dirs = ["Buzz buzz", "Honey", "Strings", "Stale", "Comb"];
       cloudLocalJson.forEach((String key, dynamic value) {
-        String? dir=null;
+        String? dir = null;
         dirs.forEach((_dir) {
           if (File("/storage/emulated/0/DCIM/$_dir/$key.jpg").existsSync()) {
             dir = _dir;
           }
         });
-        if(dir == null){
+        if (dir == null) {
           return;
         }
-        images.add(ContactEntry.fromJson(key,
-            "/storage/emulated/0/DCIM/$dir/$key.jpg", jsonDecode(value)));
+        images.add(ContactEntry.fromJson(
+            key, "/storage/emulated/0/DCIM/$dir/$key.jpg", jsonDecode(value)));
       });
 
       StorageUtils.merge(cloudLocalJson)
@@ -246,9 +247,10 @@ class CloudUtils {
 
   static Future _useDriveAPI(Function callback) async {
     if (!(await _googleSignIn.isSignedIn())) {
-      throw Exception();
+      throw Exception('Not signed in');
     }
-    final AuthClient client = (await _getAuthClient())!;
+    final AuthClient? client = await _getAuthClient();
+    if (client == null) throw Exception('Authentication failed');
 
     // Initialize DriveAPI
     // developer.log("getting DriveApi");


### PR DESCRIPTION
## Summary
- ensure Google sign-in completes before Google APIs are used
- surface sign-in failures to the user

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68884bda9f34832d87c47a66ff99f8cb