### PR TITLE
docs: add function doc guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ This repository contains a Flutter application. A setup script is automatically 
 - Format code with `dart format -o write .` before committing.
 - Generated files (`*.g.dart`) are produced via `flutter pub run build_runner build --delete-conflicting-outputs`. Run this after editing source files that depend on code generation.
 - Do not commit `lib/apiSecretKeys.dart` – this file is ignored and can contain local secrets.
+- Any new function added to Flutter code must include a documentation comment
+  using the standard Flutter format, describing the function's action and
+  purpose when applicable.
 
 ## Testing
 Run tests with:


### PR DESCRIPTION
## Summary
- require documentation comments for new Flutter functions

## Testing
- `flutter test` *(fails: The getter 'Permission' isn't defined for the class '_ImageGalleryScreenState')*

------
https://chatgpt.com/codex/tasks/task_e_688e531975c4832d88a19269a1dde19a