### PR TITLE
feat: add crop-based redo to new gallery

### DIFF
--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:async';
 
 import 'package:PhotoWordFind/models/contactEntry.dart';
 import 'package:PhotoWordFind/social_icons.dart';
@@ -11,6 +12,7 @@ import 'package:photo_manager/photo_manager.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -64,7 +66,6 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
 
   bool _controlsExpanded = true; // Tracks whether the controls are minimized
 
-  late Future<bool> _isSignedInFuture; // Tracks Google sign-in status
   bool _isInitializing = true; // Tracks if app is still initializing
   String? _initializationError; // Stores any initialization error
 
@@ -781,23 +782,24 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
                     if (states.where((s) => s != 'All').isNotEmpty)
                       Wrap(
                         spacing: 6,
-                        children: states
-                            .where((s) => s != 'All')
-                            .map(
-                              (s) => ChoiceChip(
-                                label: Text(s),
-                                selected: selected == s,
-                                onSelected: (_) {
-                                  setState(() {
-                                    selected = s;
-                                    controller.text = s;
-                                  });
-                                },
+                        children: [
+                          ...states
+                              .where((s) => s != 'All')
+                              .map(
+                                (s) => ChoiceChip(
+                                  label: Text(s),
+                                  selected: selected == s,
+                                  onSelected: (_) {
+                                    setState(() {
+                                      selected = s;
+                                      controller.text = s;
+                                    });
+                                  },
+                                ),
                               ),
-                            )
-                            .toList(),
+                          const SizedBox(height: 8),
+                        ],
                       ),
-                    const SizedBox(height: 8),
                     TextField(
                       controller: controller,
                       decoration: const InputDecoration(labelText: 'State'),
@@ -1101,212 +1103,7 @@ class _ImageTileState extends State<ImageTile> {
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-        onTap: () => _showDetailsDialog(context),
-        onLongPress: () => widget.onSelected(widget.identifier),
-        child: LayoutBuilder(builder: (context, constraints) {
-          return Container(
-              margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              width: constraints.maxWidth * 0.8,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(16),
-                border: widget.isSelected
-                    ? Border.all(color: Colors.blueAccent, width: 3)
-                    : null,
-                boxShadow: const [
-                  BoxShadow(
-                    color: Colors.black26,
-                    blurRadius: 6,
-                    offset: Offset(0, 4),
-                  ),
-                ],
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(16),
-                child: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: PhotoView(
-                        imageProvider: FileImage(File(widget.imagePath)),
-                        backgroundDecoration:
-                            const BoxDecoration(color: Colors.white),
-                        minScale: PhotoViewComputedScale.contained,
-                        maxScale: PhotoViewComputedScale.covered * 2.5,
-                      ),
-                    ),
-                    Positioned(
-                      top: 8,
-                      left: 8,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ConstrainedBox(
-                            constraints: BoxConstraints(
-                                maxWidth: constraints.maxWidth - 50),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                  vertical: 2, horizontal: 6),
-                              decoration: BoxDecoration(
-                                color: Colors.black54,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                              child: Text(
-                                _displayLabel,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 12,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 4),
-                          GestureDetector(
-                            onTap: () => widget.onSelected(widget.identifier),
-                            child: Icon(
-                              widget.isSelected
-                                  ? Icons.check_circle
-                                  : Icons.radio_button_unchecked,
-                              color: widget.isSelected
-                                  ? Colors.blueAccent
-                                  : Colors.grey,
-                              size: 28,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Positioned(
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      child: Container(
-                        height: 56,
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        decoration: const BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [Colors.transparent, Colors.black54],
-                          ),
-                        ),
-                        child: Row(
-                          children: [
-                            Text(
-                              _truncatedText,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                            Flexible(
-                              child: SingleChildScrollView(
-                                scrollDirection: Axis.horizontal,
-                                child: Row(
-                                  children: [
-                                    if (widget
-                                            .contact.snapUsername?.isNotEmpty ??
-                                        false)
-                                      IconButton(
-                                        iconSize: 22,
-                                        color: Colors.white,
-                                        padding: EdgeInsets.zero,
-                                        constraints:
-                                            const BoxConstraints.tightFor(
-                                                width: 36, height: 36),
-                                        onPressed: () => _openSocial(
-                                            SocialType.Snapchat,
-                                            widget.contact.snapUsername!),
-                                        icon: SocialIcon
-                                            .snapchatIconButton!.socialIcon,
-                                      ),
-                                    if (widget.contact.instaUsername
-                                            ?.isNotEmpty ??
-                                        false)
-                                      IconButton(
-                                        iconSize: 22,
-                                        color: Colors.white,
-                                        padding: EdgeInsets.zero,
-                                        constraints:
-                                            const BoxConstraints.tightFor(
-                                                width: 36, height: 36),
-                                        onPressed: () => _openSocial(
-                                            SocialType.Instagram,
-                                            widget.contact.instaUsername!),
-                                        icon: SocialIcon
-                                            .instagramIconButton!.socialIcon,
-                                      ),
-                                    if (widget.contact.discordUsername
-                                            ?.isNotEmpty ??
-                                        false)
-                                      IconButton(
-                                        iconSize: 22,
-                                        color: Colors.white,
-                                        padding: EdgeInsets.zero,
-                                        constraints:
-                                            const BoxConstraints.tightFor(
-                                                width: 36, height: 36),
-                                        onPressed: () => _openSocial(
-                                            SocialType.Discord,
-                                            widget.contact.discordUsername!),
-                                        icon: SocialIcon
-                                            .discordIconButton!.socialIcon,
-                                      ),
-                                    IconButton(
-                                      iconSize: 22,
-                                      color: Colors.white,
-                                      padding: EdgeInsets.zero,
-                                      constraints:
-                                          const BoxConstraints.tightFor(
-                                              width: 36, height: 36),
-                                      icon: const Icon(Icons.note_alt_outlined),
-                                      onPressed: () async {
-                                        await showNoteDialog(
-                                            context,
-                                            widget.contact.identifier,
-                                            widget.contact,
-                                            existingNotes:
-                                                widget.contact.notes);
-                                      },
-                                    ),
-                                    IconButton(
-                                      iconSize: 22,
-                                      color: Colors.white,
-                                      padding: EdgeInsets.zero,
-                                      constraints:
-                                          const BoxConstraints.tightFor(
-                                              width: 36, height: 36),
-                                      icon: const Icon(Icons.edit),
-                                      onPressed: () => _editUsernames(context),
-                                    ),
-                                    IconButton(
-                                      iconSize: 22,
-                                      color: Colors.white,
-                                      padding: EdgeInsets.zero,
-                                      constraints:
-                                          const BoxConstraints.tightFor(
-                                              width: 36, height: 36),
-                                      icon: const Icon(Icons.more_vert),
-                                      onPressed: () => _showPopupMenu(
-                                          context, widget.imagePath),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              )); // closes LayoutBuilder
-        })); // closes GestureDetector
-  }
-
+  // Move all helper methods above build
   void _showPopupMenu(BuildContext context, String imagePath) {
     showModalBottomSheet(
       context: context,
@@ -1621,7 +1418,7 @@ class _ImageTileState extends State<ImageTile> {
     switch (social) {
       case SocialType.Snapchat:
         url =
-            Uri.parse('https://www.snapchat.com/add/${username.toLowerCase()}');
+            Uri.parse('https://www.snapchat.com/add/{username.toLowerCase()}');
         break;
       case SocialType.Instagram:
         url = Uri.parse('https://www.instagram.com/$username');
@@ -1677,5 +1474,236 @@ class _ImageTileState extends State<ImageTile> {
         });
       }
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => _showDetailsDialog(context),
+      onLongPress: () => widget.onSelected(widget.identifier),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Container(
+            margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            width: constraints.maxWidth * 0.8,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              border: widget.isSelected
+                  ? Border.all(color: Colors.blueAccent, width: 3)
+                  : null,
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black26,
+                  blurRadius: 6,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: PhotoView(
+                      imageProvider: FileImage(File(widget.imagePath)),
+                      backgroundDecoration:
+                          const BoxDecoration(color: Colors.white),
+                      minScale: PhotoViewComputedScale.contained,
+                      maxScale: PhotoViewComputedScale.covered * 2.5,
+                    ),
+                  ),
+                  // Redo OCR button overlay
+                  Positioned(
+                    top: 8,
+                    right: 8,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.black45,
+                        shape: BoxShape.circle,
+                      ),
+                      child: IconButton(
+                        iconSize: 24,
+                        padding: EdgeInsets.all(8),
+                        icon: const Icon(Icons.refresh, color: Colors.white),
+                        tooltip: 'Redo OCR',
+                        onPressed: () async {
+                          await _redoTextExtraction();
+                        },
+                      ),
+                    ),
+                  ),
+                  // Existing info and selection UI
+                  Positioned(
+                    top: 8,
+                    left: 8,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ConstrainedBox(
+                          constraints: BoxConstraints(
+                              maxWidth: constraints.maxWidth - 50),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 2, horizontal: 6),
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              _displayLabel,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        GestureDetector(
+                          onTap: () => widget.onSelected(widget.identifier),
+                          child: Icon(
+                            widget.isSelected
+                                ? Icons.check_circle
+                                : Icons.radio_button_unchecked,
+                            color: widget.isSelected
+                                ? Colors.blueAccent
+                                : Colors.grey,
+                            size: 28,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: Container(
+                      height: 56,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      decoration: const BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [Colors.transparent, Colors.black54],
+                        ),
+                      ),
+                      child: Row(
+                        children: [
+                          Text(
+                            _truncatedText,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          Flexible(
+                            child: SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              child: Row(
+                                children: [
+                                  if (widget
+                                          .contact.snapUsername?.isNotEmpty ??
+                                      false)
+                                    IconButton(
+                                      iconSize: 22,
+                                      color: Colors.white,
+                                      padding: EdgeInsets.zero,
+                                      constraints:
+                                          const BoxConstraints.tightFor(
+                                              width: 36, height: 36),
+                                      onPressed: () => _openSocial(
+                                          SocialType.Snapchat,
+                                          widget.contact.snapUsername!),
+                                      icon: SocialIcon
+                                          .snapchatIconButton!.socialIcon,
+                                    ),
+                                  if (widget.contact.instaUsername
+                                          ?.isNotEmpty ??
+                                      false)
+                                    IconButton(
+                                      iconSize: 22,
+                                      color: Colors.white,
+                                      padding: EdgeInsets.zero,
+                                      constraints:
+                                          const BoxConstraints.tightFor(
+                                              width: 36, height: 36),
+                                      onPressed: () => _openSocial(
+                                          SocialType.Instagram,
+                                          widget.contact.instaUsername!),
+                                      icon: SocialIcon
+                                          .instagramIconButton!.socialIcon,
+                                    ),
+                                  if (widget.contact.discordUsername
+                                          ?.isNotEmpty ??
+                                      false)
+                                    IconButton(
+                                      iconSize: 22,
+                                      color: Colors.white,
+                                      padding: EdgeInsets.zero,
+                                      constraints:
+                                          const BoxConstraints.tightFor(
+                                              width: 36, height: 36),
+                                      onPressed: () => _openSocial(
+                                          SocialType.Discord,
+                                          widget.contact.discordUsername!),
+                                      icon: SocialIcon
+                                          .discordIconButton!.socialIcon,
+                                    ),
+                                  IconButton(
+                                    iconSize: 22,
+                                    color: Colors.white,
+                                    padding: EdgeInsets.zero,
+                                    constraints:
+                                        const BoxConstraints.tightFor(
+                                            width: 36, height: 36),
+                                    icon: const Icon(Icons.note_alt_outlined),
+                                    onPressed: () async {
+                                      await showNoteDialog(
+                                          context,
+                                          widget.contact.identifier,
+                                          widget.contact,
+                                          existingNotes:
+                                              widget.contact.notes);
+                                    },
+                                  ),
+                                  IconButton(
+                                    iconSize: 22,
+                                    color: Colors.white,
+                                    padding: EdgeInsets.zero,
+                                    constraints:
+                                        const BoxConstraints.tightFor(
+                                            width: 36, height: 36),
+                                    icon: const Icon(Icons.edit),
+                                    onPressed: () => _editUsernames(context),
+                                  ),
+                                  IconButton(
+                                    iconSize: 22,
+                                    color: Colors.white,
+                                    padding: EdgeInsets.zero,
+                                    constraints:
+                                        const BoxConstraints.tightFor(
+                                            width: 36, height: 36),
+                                    icon: const Icon(Icons.more_vert),
+                                    onPressed: () => _showPopupMenu(
+                                        context, widget.imagePath),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -1526,8 +1526,8 @@ class _ImageTileState extends State<ImageTile> {
                           await _redoTextExtraction();
                         },
                         child: Container(
-                          width: 48,
-                          height: 48,
+                          width: 36,
+                          height: 36,
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
                             gradient: const LinearGradient(
@@ -1548,7 +1548,7 @@ class _ImageTileState extends State<ImageTile> {
                             child: Icon(
                               Icons.refresh,
                               color: Colors.white,
-                              size: 28,
+                              size: 20,
                             ),
                           ),
                         ),

--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -1516,19 +1516,42 @@ class _ImageTileState extends State<ImageTile> {
                   Positioned(
                     top: 8,
                     right: 8,
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Colors.black45,
-                        shape: BoxShape.circle,
-                      ),
-                      child: IconButton(
-                        iconSize: 24,
-                        padding: EdgeInsets.all(8),
-                        icon: const Icon(Icons.refresh, color: Colors.white),
-                        tooltip: 'Redo OCR',
-                        onPressed: () async {
+                    child: Material(
+                      color: Colors.transparent,
+                      shape: const CircleBorder(),
+                      elevation: 4,
+                      child: InkWell(
+                        customBorder: const CircleBorder(),
+                        onTap: () async {
                           await _redoTextExtraction();
                         },
+                        child: Container(
+                          width: 48,
+                          height: 48,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            gradient: const LinearGradient(
+                              colors: [Color(0xFF4F8CFF), Color(0xFF8F5CFF)],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            border: Border.all(color: Colors.white, width: 2),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black26,
+                                blurRadius: 8,
+                                offset: Offset(0, 2),
+                              ),
+                            ],
+                          ),
+                          child: const Center(
+                            child: Icon(
+                              Icons.refresh,
+                              color: Colors.white,
+                              size: 28,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/experimental/2attempt/imageGalleryScreen.dart
+++ b/lib/experimental/2attempt/imageGalleryScreen.dart
@@ -1460,14 +1460,14 @@ class _ImageTileState extends State<ImageTile> {
   }
 
   Future<void> _redoTextExtraction() async {
-    final newText = await Navigator.of(context).push<String>(
+    final result = await Navigator.of(context).push<Map<String, dynamic>>(
       MaterialPageRoute(
         builder: (_) => RedoCropScreen(imageFile: File(widget.imagePath)),
       ),
     );
-    if (newText != null) {
+    if (result != null) {
       setState(() {
-        widget.contact.extractedText = newText;
+        postProcessChatGptResult(widget.contact, result, save: false);
       });
       await StorageUtils.save(widget.contact, backup: false);
     }

--- a/lib/experimental/2attempt/redo_crop_screen.dart
+++ b/lib/experimental/2attempt/redo_crop_screen.dart
@@ -1,8 +1,12 @@
 import 'dart:io';
+import 'dart:ui' as ui;
+import 'dart:typed_data';
+import 'dart:math' as math;
 
-import 'package:crop_your_image/crop_your_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:photo_view/photo_view.dart';
 
 import 'package:PhotoWordFind/services/chat_gpt_service.dart';
 
@@ -16,28 +20,153 @@ class RedoCropScreen extends StatefulWidget {
 }
 
 class _RedoCropScreenState extends State<RedoCropScreen> {
-  final CropController _controller = CropController();
+  final PhotoViewController _photoController = PhotoViewController();
   bool _processing = false;
   static bool _hintShown = false;
   late bool _showHint;
+  
+  // Crop area state
+  Rect _cropRect = const Rect.fromLTWH(50, 100, 200, 200);
+  bool _isDragging = false;
+  bool _isResizing = false;
+  Offset? _dragStart;
+  String? _resizeHandle; // 'tl', 'tr', 'bl', 'br' for corners
 
   @override
   void initState() {
     super.initState();
     _showHint = !_hintShown;
     _hintShown = true;
+    
+    // Set initial crop area to center of screen
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final size = MediaQuery.of(context).size;
+      setState(() {
+        _cropRect = Rect.fromCenter(
+          center: Offset(size.width / 2, size.height / 2),
+          width: size.width * 0.6,
+          height: size.height * 0.3,
+        );
+      });
+    });
   }
 
-  Future<void> _onCropped(CropResult result) async {
-    if (result is! CropSuccess) return;
-    setState(() => _processing = true);
-    final dir = await getTemporaryDirectory();
-    final file = await File('${dir.path}/redo.png').create();
-    await file.writeAsBytes(result.croppedImage);
+  @override
+  void dispose() {
+    _photoController.dispose();
+    super.dispose();
+  }
 
-    final response = await ChatGPTService.processImage(imageFile: file);
-    if (!mounted) return;
-    Navigator.pop(context, response);
+  Future<void> _captureCroppedArea() async {
+    setState(() => _processing = true);
+    
+    try {
+      // Load the original image
+      final imageBytes = await widget.imageFile.readAsBytes();
+      final codec = await ui.instantiateImageCodec(imageBytes);
+      final frame = await codec.getNextFrame();
+      final originalImage = frame.image;
+      
+      // Get screen dimensions
+      final screenSize = MediaQuery.of(context).size;
+      
+      // Calculate the actual image dimensions and position on screen
+      // PhotoView uses "contained" scale by default, so image fits within screen
+      final imageAspectRatio = originalImage.width / originalImage.height;
+      final screenAspectRatio = screenSize.width / screenSize.height;
+      
+      late double imageWidthOnScreen;
+      late double imageHeightOnScreen;
+      late double imageLeftOnScreen;
+      late double imageTopOnScreen;
+      
+      if (imageAspectRatio > screenAspectRatio) {
+        // Image is wider than screen ratio - fits by width
+        imageWidthOnScreen = screenSize.width;
+        imageHeightOnScreen = screenSize.width / imageAspectRatio;
+        imageLeftOnScreen = 0;
+        imageTopOnScreen = (screenSize.height - imageHeightOnScreen) / 2;
+      } else {
+        // Image is taller than screen ratio - fits by height
+        imageWidthOnScreen = screenSize.height * imageAspectRatio;
+        imageHeightOnScreen = screenSize.height;
+        imageLeftOnScreen = (screenSize.width - imageWidthOnScreen) / 2;
+        imageTopOnScreen = 0;
+      }
+      
+      // Convert crop rect from screen coordinates to image coordinates
+      final cropLeft = (_cropRect.left - imageLeftOnScreen) / imageWidthOnScreen;
+      final cropTop = (_cropRect.top - imageTopOnScreen) / imageHeightOnScreen;
+      final cropWidth = _cropRect.width / imageWidthOnScreen;
+      final cropHeight = _cropRect.height / imageHeightOnScreen;
+      
+      // Clamp values to valid range
+      final clampedLeft = math.max(0.0, math.min(1.0, cropLeft));
+      final clampedTop = math.max(0.0, math.min(1.0, cropTop));
+      final clampedRight = math.max(0.0, math.min(1.0, cropLeft + cropWidth));
+      final clampedBottom = math.max(0.0, math.min(1.0, cropTop + cropHeight));
+      
+      // Convert to pixel coordinates
+      final pixelLeft = (clampedLeft * originalImage.width).round();
+      final pixelTop = (clampedTop * originalImage.height).round();
+      final pixelRight = (clampedRight * originalImage.width).round();
+      final pixelBottom = (clampedBottom * originalImage.height).round();
+      
+      final cropRect = Rect.fromLTRB(
+        pixelLeft.toDouble(),
+        pixelTop.toDouble(), 
+        pixelRight.toDouble(),
+        pixelBottom.toDouble(),
+      );
+      
+      // Crop the image
+      final croppedImage = await _cropImage(imageBytes, cropRect);
+      
+      // Save cropped image
+      final dir = await getTemporaryDirectory();
+      final file = await File('${dir.path}/redo.png').create();
+      await file.writeAsBytes(croppedImage);
+
+      final response = await ChatGPTService.processImage(imageFile: file);
+      if (!mounted) return;
+      Navigator.pop(context, response);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to process crop: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _processing = false);
+      }
+    }
+  }
+
+  Future<Uint8List> _cropImage(Uint8List imageBytes, Rect cropRect) async {
+    final codec = await ui.instantiateImageCodec(imageBytes);
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+    
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    
+    // Draw the cropped portion
+    canvas.drawImageRect(
+      image,
+      cropRect,
+      Rect.fromLTWH(0, 0, cropRect.width, cropRect.height),
+      Paint(),
+    );
+    
+    final picture = recorder.endRecording();
+    final croppedImage = await picture.toImage(cropRect.width.round(), cropRect.height.round());
+    final byteData = await croppedImage.toByteData(format: ui.ImageByteFormat.png);
+    
+    image.dispose();
+    croppedImage.dispose();
+    
+    return byteData!.buffer.asUint8List();
   }
 
   @override
@@ -46,47 +175,140 @@ class _RedoCropScreenState extends State<RedoCropScreen> {
       backgroundColor: Colors.black,
       body: Stack(
         children: [
-          Crop(
-            controller: _controller,
-            image: widget.imageFile.readAsBytesSync(),
-            onCropped: _onCropped,
+          // Interactive PhotoView background
+          PhotoView(
+            imageProvider: FileImage(widget.imageFile),
+            backgroundDecoration: const BoxDecoration(color: Colors.black),
+            minScale: PhotoViewComputedScale.contained * 0.8,
+            maxScale: PhotoViewComputedScale.covered * 3.0,
+            controller: _photoController,
+            enableRotation: false,
+            filterQuality: FilterQuality.high,
           ),
+          
+          // Crop overlay
+          Positioned.fill(
+            child: GestureDetector(
+              onPanStart: (details) {
+                final localPosition = details.localPosition;
+                final handle = _getResizeHandle(localPosition);
+                
+                if (handle != null) {
+                  setState(() {
+                    _isResizing = true;
+                    _resizeHandle = handle;
+                    _dragStart = localPosition;
+                  });
+                } else if (_cropRect.contains(localPosition)) {
+                  setState(() {
+                    _isDragging = true;
+                    _dragStart = localPosition;
+                  });
+                }
+              },
+              onPanUpdate: (details) {
+                if (_isDragging && _dragStart != null) {
+                  final delta = details.localPosition - _dragStart!;
+                  setState(() {
+                    _cropRect = _cropRect.translate(delta.dx, delta.dy);
+                    _dragStart = details.localPosition;
+                  });
+                } else if (_isResizing && _dragStart != null && _resizeHandle != null) {
+                  _handleResize(details.localPosition);
+                }
+              },
+              onPanEnd: (details) {
+                setState(() {
+                  _isDragging = false;
+                  _isResizing = false;
+                  _dragStart = null;
+                  _resizeHandle = null;
+                });
+              },
+              child: CustomPaint(
+                painter: CropOverlayPainter(_cropRect, _isResizing, _resizeHandle),
+                child: Container(),
+              ),
+            ),
+          ),
+          
           if (_showHint)
             Positioned(
-              top: 40,
-              left: 0,
-              right: 0,
-              child: Center(
-                child: Container(
-                  padding: const EdgeInsets.all(8),
-                  color: Colors.black54,
-                  child: const Text(
-                    'Select the area to scan again',
-                    style: TextStyle(color: Colors.white),
-                  ),
+              top: 60,
+              left: 16,
+              right: 16,
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.black87,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text(
+                      '📱 Pinch to zoom, drag to move image',
+                      style: TextStyle(color: Colors.white, fontSize: 14),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 4),
+                    const Text(
+                      '✂️ Drag crop area to move, drag corners to resize',
+                      style: TextStyle(color: Colors.white, fontSize: 14),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    GestureDetector(
+                      onTap: () => setState(() => _showHint = false),
+                      child: const Text(
+                        'Got it!',
+                        style: TextStyle(color: Colors.blue, fontSize: 14, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
+          
+          // Control buttons
           Align(
             alignment: Alignment.bottomCenter,
             child: Container(
-              color: Colors.black54,
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              margin: const EdgeInsets.all(16),
+              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
+              decoration: BoxDecoration(
+                color: Colors.black87,
+                borderRadius: BorderRadius.circular(25),
+              ),
               child: _processing
                   ? const SizedBox(
                       height: 40,
-                      child: Center(child: CircularProgressIndicator()),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          CircularProgressIndicator(strokeWidth: 2),
+                          SizedBox(width: 12),
+                          Text('Processing...', style: TextStyle(color: Colors.white)),
+                        ],
+                      ),
                     )
                   : Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        TextButton(
+                        TextButton.icon(
                           onPressed: () => Navigator.pop(context),
-                          child: const Text('Cancel'),
+                          icon: const Icon(Icons.close, color: Colors.white),
+                          label: const Text('Cancel', style: TextStyle(color: Colors.white)),
                         ),
-                        ElevatedButton(
-                          onPressed: () => _controller.crop(),
-                          child: const Text('Redo'),
+                        const SizedBox(width: 16),
+                        ElevatedButton.icon(
+                          onPressed: _captureCroppedArea,
+                          icon: const Icon(Icons.crop),
+                          label: const Text('Redo OCR'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.blue,
+                            foregroundColor: Colors.white,
+                          ),
                         ),
                       ],
                     ),
@@ -95,5 +317,186 @@ class _RedoCropScreenState extends State<RedoCropScreen> {
         ],
       ),
     );
+  }
+
+  String? _getResizeHandle(Offset position) {
+    const handleSize = 20.0;
+    
+    // Check corners for resize handles
+    if ((position - _cropRect.topLeft).distance <= handleSize) {
+      return 'tl'; // top-left
+    }
+    if ((position - _cropRect.topRight).distance <= handleSize) {
+      return 'tr'; // top-right
+    }
+    if ((position - _cropRect.bottomLeft).distance <= handleSize) {
+      return 'bl'; // bottom-left
+    }
+    if ((position - _cropRect.bottomRight).distance <= handleSize) {
+      return 'br'; // bottom-right
+    }
+    
+    return null;
+  }
+
+  void _handleResize(Offset currentPosition) {
+    final delta = currentPosition - _dragStart!;
+    
+    setState(() {
+      switch (_resizeHandle) {
+        case 'tl':
+          _cropRect = Rect.fromLTRB(
+            _cropRect.left + delta.dx,
+            _cropRect.top + delta.dy,
+            _cropRect.right,
+            _cropRect.bottom,
+          );
+          break;
+        case 'tr':
+          _cropRect = Rect.fromLTRB(
+            _cropRect.left,
+            _cropRect.top + delta.dy,
+            _cropRect.right + delta.dx,
+            _cropRect.bottom,
+          );
+          break;
+        case 'bl':
+          _cropRect = Rect.fromLTRB(
+            _cropRect.left + delta.dx,
+            _cropRect.top,
+            _cropRect.right,
+            _cropRect.bottom + delta.dy,
+          );
+          break;
+        case 'br':
+          _cropRect = Rect.fromLTRB(
+            _cropRect.left,
+            _cropRect.top,
+            _cropRect.right + delta.dx,
+            _cropRect.bottom + delta.dy,
+          );
+          break;
+      }
+      
+      // Ensure minimum size
+      const minSize = 50.0;
+      if (_cropRect.width < minSize || _cropRect.height < minSize) {
+        final center = _cropRect.center;
+        _cropRect = Rect.fromCenter(
+          center: center,
+          width: math.max(_cropRect.width, minSize),
+          height: math.max(_cropRect.height, minSize),
+        );
+      }
+      
+      _dragStart = currentPosition;
+    });
+  }
+}
+
+// Custom painter for the crop overlay
+class CropOverlayPainter extends CustomPainter {
+  final Rect cropRect;
+  final bool isResizing;
+  final String? resizeHandle;
+  
+  CropOverlayPainter(this.cropRect, this.isResizing, this.resizeHandle);
+  
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Draw overlay outside crop area
+    final overlayPaint = Paint()
+      ..color = Colors.black54
+      ..style = PaintingStyle.fill;
+    
+    final path = Path()
+      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height))
+      ..addRect(cropRect)
+      ..fillType = PathFillType.evenOdd;
+    
+    canvas.drawPath(path, overlayPaint);
+    
+    // Draw crop border
+    final borderPaint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0;
+    
+    canvas.drawRect(cropRect, borderPaint);
+    
+    // Draw corner handles
+    final handlePaint = Paint()
+      ..color = isResizing ? Colors.blue : Colors.white
+      ..style = PaintingStyle.fill;
+    
+    final handleBorderPaint = Paint()
+      ..color = Colors.black
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.0;
+    
+    const handleSize = 12.0;
+    final corners = [
+      (cropRect.topLeft, 'tl'),
+      (cropRect.topRight, 'tr'),
+      (cropRect.bottomLeft, 'bl'),
+      (cropRect.bottomRight, 'br'),
+    ];
+    
+    for (final (corner, handle) in corners) {
+      final isActiveHandle = handle == resizeHandle;
+      final paint = isActiveHandle ? 
+        (Paint()..color = Colors.blue..style = PaintingStyle.fill) : 
+        handlePaint;
+      
+      canvas.drawCircle(corner, handleSize, paint);
+      canvas.drawCircle(corner, handleSize, handleBorderPaint);
+      
+      // Draw inner dot for better visibility
+      final innerPaint = Paint()
+        ..color = isActiveHandle ? Colors.white : Colors.black
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(corner, handleSize * 0.3, innerPaint);
+    }
+    
+    // Draw grid lines for better cropping guidance
+    final gridPaint = Paint()
+      ..color = Colors.white.withOpacity(0.3)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.0;
+    
+    // Rule of thirds lines
+    final thirdWidth = cropRect.width / 3;
+    final thirdHeight = cropRect.height / 3;
+    
+    // Vertical lines
+    canvas.drawLine(
+      Offset(cropRect.left + thirdWidth, cropRect.top),
+      Offset(cropRect.left + thirdWidth, cropRect.bottom),
+      gridPaint,
+    );
+    canvas.drawLine(
+      Offset(cropRect.left + 2 * thirdWidth, cropRect.top),
+      Offset(cropRect.left + 2 * thirdWidth, cropRect.bottom),
+      gridPaint,
+    );
+    
+    // Horizontal lines
+    canvas.drawLine(
+      Offset(cropRect.left, cropRect.top + thirdHeight),
+      Offset(cropRect.right, cropRect.top + thirdHeight),
+      gridPaint,
+    );
+    canvas.drawLine(
+      Offset(cropRect.left, cropRect.top + 2 * thirdHeight),
+      Offset(cropRect.right, cropRect.top + 2 * thirdHeight),
+      gridPaint,
+    );
+  }
+  
+  @override
+  bool shouldRepaint(CropOverlayPainter oldDelegate) {
+    return oldDelegate.cropRect != cropRect || 
+           oldDelegate.isResizing != isResizing ||
+           oldDelegate.resizeHandle != resizeHandle;
   }
 }

--- a/lib/experimental/2attempt/redo_crop_screen.dart
+++ b/lib/experimental/2attempt/redo_crop_screen.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:crop_your_image/crop_your_image.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:PhotoWordFind/utils/image_utils.dart';
+
+class RedoCropScreen extends StatefulWidget {
+  const RedoCropScreen({super.key, required this.imageFile});
+
+  final File imageFile;
+
+  @override
+  State<RedoCropScreen> createState() => _RedoCropScreenState();
+}
+
+class _RedoCropScreenState extends State<RedoCropScreen> {
+  final CropController _controller = CropController();
+  bool _processing = false;
+  static bool _hintShown = false;
+  late bool _showHint;
+
+  @override
+  void initState() {
+    super.initState();
+    _showHint = !_hintShown;
+    _hintShown = true;
+  }
+
+  Future<void> _onCropped(CropResult result) async {
+    if (result is! CropSuccess) return;
+    setState(() => _processing = true);
+    final dir = await getTemporaryDirectory();
+    final file = await File('${dir.path}/redo.png').create();
+    await file.writeAsBytes(result.croppedImage);
+    final text = await OCR(file.path);
+    if (!mounted) return;
+    Navigator.pop(context, text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          Crop(
+            controller: _controller,
+            image: widget.imageFile.readAsBytesSync(),
+            onCropped: _onCropped,
+          ),
+          if (_showHint)
+            Positioned(
+              top: 40,
+              left: 0,
+              right: 0,
+              child: Center(
+                child: Container(
+                  padding: const EdgeInsets.all(8),
+                  color: Colors.black54,
+                  child: const Text(
+                    'Select the area to scan again',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
+            ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(
+              color: Colors.black54,
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: _processing
+                  ? const SizedBox(
+                      height: 40,
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  : Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: const Text('Cancel'),
+                        ),
+                        ElevatedButton(
+                          onPressed: () => _controller.crop(),
+                          child: const Text('Redo'),
+                        ),
+                      ],
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/experimental/2attempt/redo_crop_screen.dart
+++ b/lib/experimental/2attempt/redo_crop_screen.dart
@@ -4,7 +4,7 @@ import 'package:crop_your_image/crop_your_image.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
-import 'package:PhotoWordFind/utils/image_utils.dart';
+import 'package:PhotoWordFind/services/chat_gpt_service.dart';
 
 class RedoCropScreen extends StatefulWidget {
   const RedoCropScreen({super.key, required this.imageFile});
@@ -34,9 +34,10 @@ class _RedoCropScreenState extends State<RedoCropScreen> {
     final dir = await getTemporaryDirectory();
     final file = await File('${dir.path}/redo.png').create();
     await file.writeAsBytes(result.croppedImage);
-    final text = await OCR(file.path);
+
+    final response = await ChatGPTService.processImage(imageFile: file);
     if (!mounted) return;
-    Navigator.pop(context, text);
+    Navigator.pop(context, response);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,10 +34,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.7"
   args:
     dependency: transitive
     description:
@@ -206,6 +206,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  crop_your_image:
+    dependency: "direct main"
+    description:
+      name: crop_your_image
+      sha256: "14c8977b11a009dc5e73e0f6522970f93363e38183f1b2ffefe1676dc9c3f49d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   cross_file:
     dependency: transitive
     description:
@@ -633,10 +641,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.5.4"
   image_picker:
     dependency: "direct main"
     description:
@@ -1037,6 +1045,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3"
   provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   # Photo gallery functionality
   photo_view: ^0.14.0
 
+  crop_your_image: ^2.0.0
+
   # For little faded notification on screen
   fluttertoast: ^8.0.8
 


### PR DESCRIPTION
## Summary
- add redo cropping overlay for re-scanning text in new gallery UI
- wire redo menu option to launch cropping flow
- include crop_your_image dependency

## Testing
- `flutter test` *(fails: ImageGalleryScreen shows loading state during initialization)*

------
https://chatgpt.com/codex/tasks/task_e_688e53fd648c832da027e37f861b815f