### PR TITLE
Feature/location sorting

### DIFF
--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -74,6 +74,9 @@ class StorageUtils {
     'gallery_snap_added_filter_v1',
     'gallery_insta_added_filter_v1',
     'gallery_selected_states_multi_v1',
+  // Sorting preferences
+  'gallery_sort_option_v1',
+  'gallery_sort_ascending_v1',
   };
 
   // --- Debounced save coalescing (per-entry) ---

--- a/lib/utils/storage_utils.dart
+++ b/lib/utils/storage_utils.dart
@@ -77,6 +77,9 @@ class StorageUtils {
   // Sorting preferences
   'gallery_sort_option_v1',
   'gallery_sort_ascending_v1',
+  // Time difference filter prefs
+  'gallery_time_diff_min_v1',
+  'gallery_time_diff_max_v1',
   };
 
   // --- Debounced save coalescing (per-entry) ---


### PR DESCRIPTION
This pull request adds a new "Location" sort and filter option to the image gallery, allowing users to filter and sort images based on the relative timezone difference between the image's location and the device's local time. It also refactors the filter sheet to apply changes immediately and persist both filter and sort settings. The changes improve the user experience for timezone-based organization and ensure filter/sort states are saved and restored.

**New Location-based filtering and sorting:**

* Added "Location" to the sort options and filter sheet, enabling users to sort and filter images by the relative timezone difference between the image's location and the device's local time. Filtering uses a new range slider for time difference, and sorting is stable and deterministic. (`lib/screens/gallery/image_gallery_screen.dart`, `lib/screens/gallery/widgets/image_tile.dart`) [[1]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L112-R113) [[2]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L1069-R1095) [[3]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L1505-R1648) [[4]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1690-R1727) [[5]](diffhunk://#diff-a452a2d296f6ca67d9243bb09a0083ac5beb3d85be49570dc323f30f590e8a14R76-R151)

**UI and filter sheet improvements:**

* The filter sheet now applies changes immediately as users interact, with a "Done" button to close and a "Reset" button to restore defaults and apply them right away. This removes the need for temporary variables and simplifies the filter logic. (`lib/screens/gallery/image_gallery_screen.dart`) [[1]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1030-R1036) [[2]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1056-R1072) [[3]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L1069-R1095) [[4]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L1109-L1120)

**Persistence of filter and sort settings:**

* Filter and sort settings, including the new time difference range and sort direction/option, are now persisted using shared preferences. These settings are restored when the app is reopened, maintaining user preferences. (`lib/screens/gallery/image_gallery_screen.dart`) [[1]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R181-R185) [[2]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1497-R1505) [[3]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1543-R1546)

**Immediate persistence and application of changes:**

* All filter and sort changes trigger immediate persistence and re-filtering/re-sorting of the image list, ensuring the UI always reflects the latest settings. (`lib/screens/gallery/image_gallery_screen.dart`) [[1]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R822) [[2]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R976) [[3]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1455)

**Robust handling of timezone offset units:**

* Added normalization logic to reliably interpret timezone offsets in minutes, seconds, milliseconds, or microseconds, both for filtering and display. This ensures correct handling regardless of the source unit. (`lib/screens/gallery/image_gallery_screen.dart`, `lib/screens/gallery/widgets/image_tile.dart`) [[1]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8L1505-R1648) [[2]](diffhunk://#diff-af0bf8fea5ca1adff5d52f9efe8148e3688a4239748bdaa9a031536d961424d8R1690-R1727) [[3]](diffhunk://#diff-a452a2d296f6ca67d9243bb09a0083ac5beb3d85be49570dc323f30f590e8a14R76-R151)