### PR TITLE
Add selection mode to image gallery and fix tile re-ordering

### DIFF
--- a/lib/screens/gallery/image_gallery_screen.dart
+++ b/lib/screens/gallery/image_gallery_screen.dart
@@ -608,7 +608,22 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
   }
 
   List<Widget> _buildAppBarActions(BuildContext navContext) {
-    return [
+    final actions = <Widget>[];
+
+    // If in selection mode, show a Clear/Cancel button to exit selection state.
+    if (selectedImages.isNotEmpty) {
+      actions.add(
+        IconButton(
+          tooltip: 'Cancel selection',
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            setState(() => selectedImages.clear());
+          },
+        ),
+      );
+    }
+
+    actions.addAll([
       if (_redoMode)
         Padding(
           padding: const EdgeInsets.only(right: 4.0),
@@ -778,7 +793,9 @@ class _ImageGalleryScreenState extends State<ImageGalleryScreen>
             );
           },
         ),
-    ];
+  ]);
+
+  return actions;
   }
 
   // Banner prompting to enter Redo mode when items need attention

--- a/lib/screens/gallery/widgets/image_gallery.dart
+++ b/lib/screens/gallery/widgets/image_gallery.dart
@@ -71,15 +71,25 @@ class ImageGallery extends StatelessWidget {
     final width = media.size.width;
     // Aim for tiles ~180dp wide with clamped column count
     final int columns = (width / 180).floor().clamp(1, 8);
+    const double baseHPad = 8;
+    const double cross = 12;
+    // Quantize grid width so each column has an integer pixel width.
+    final usable = width - (baseHPad * 2);
+    final totalSpacing = (columns - 1) * cross;
+    final colWidth = ((usable - totalSpacing) / columns).floorToDouble();
+    final adjustedUsable = columns * colWidth + totalSpacing;
+    final extra = (usable - adjustedUsable).clamp(0, double.infinity);
+    final padLeft = baseHPad + (extra / 2);
+    final padRight = baseHPad + (extra - (extra / 2));
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8),
+      padding: EdgeInsets.only(left: padLeft, right: padRight),
       child: Stack(
         children: [
           MasonryGridView.count(
             crossAxisCount: columns,
-            mainAxisSpacing: 12,
-            crossAxisSpacing: 12,
+            mainAxisSpacing: cross,
+            crossAxisSpacing: cross,
             // Limit offscreen cache to reduce memory pressure
             cacheExtent: 600,
             padding: const EdgeInsets.only(bottom: 96, top: 8),
@@ -187,13 +197,23 @@ class SliverImageGallery extends StatelessWidget {
     final media = MediaQuery.of(context);
     final width = media.size.width;
     final int columns = (width / 180).floor().clamp(1, 8);
+    const double baseHPad = 8;
+    const double cross = 12;
+    // Quantize grid width so each column has an integer pixel width.
+    final usable = width - (baseHPad * 2);
+    final totalSpacing = (columns - 1) * cross;
+    final colWidth = ((usable - totalSpacing) / columns).floorToDouble();
+    final adjustedUsable = columns * colWidth + totalSpacing;
+    final extra = (usable - adjustedUsable).clamp(0, double.infinity);
+    final padLeft = baseHPad + (extra / 2);
+    final padRight = baseHPad + (extra - (extra / 2));
 
     return SliverPadding(
-      padding: const EdgeInsets.fromLTRB(8, 8, 8, 96),
+      padding: EdgeInsets.fromLTRB(padLeft, 8, padRight, 96),
       sliver: SliverMasonryGrid.count(
         crossAxisCount: columns,
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
+        mainAxisSpacing: cross,
+        crossAxisSpacing: cross,
         // Sliver scroller uses parent cache; spacing remains.
         childCount: images.length,
         itemBuilder: (context, index) {

--- a/lib/screens/gallery/widgets/image_gallery.dart
+++ b/lib/screens/gallery/widgets/image_gallery.dart
@@ -56,6 +56,7 @@ class ImageGallery extends StatelessWidget {
                   onSelected: onImageSelected,
                   onMenuOptionSelected: onMenuOptionSelected,
                   contact: images[index],
+                  selectionMode: selectedImages.isNotEmpty,
                 );
               },
             ),
@@ -106,6 +107,7 @@ class ImageGallery extends StatelessWidget {
                     ),
                   );
                 },
+                selectionMode: selectedImages.isNotEmpty,
               );
             },
           ),
@@ -173,6 +175,7 @@ class SliverImageGallery extends StatelessWidget {
                 onSelected: onImageSelected,
                 onMenuOptionSelected: onMenuOptionSelected,
                 contact: item,
+                selectionMode: selectedImages.isNotEmpty,
               ),
             );
           },
@@ -216,6 +219,7 @@ class SliverImageGallery extends StatelessWidget {
                 ),
               );
             },
+            selectionMode: selectedImages.isNotEmpty,
           );
         },
       ),

--- a/lib/screens/gallery/widgets/image_tile.dart
+++ b/lib/screens/gallery/widgets/image_tile.dart
@@ -41,7 +41,7 @@ class ImageTile extends StatefulWidget {
     required this.contact,
     this.gridMode = false,
     this.onOpenFullScreen,
-  this.selectionMode = false,
+    this.selectionMode = false,
   });
 
   @override
@@ -597,16 +597,13 @@ class _ImageTileState extends State<ImageTile> {
             final logicalWidth =
                 isGrid ? constraints.maxWidth : (constraints.maxWidth * 0.8);
             final imageProvider = _providerForWidth(logicalWidth);
-            return Container(
+            final tile = Container(
               margin: isGrid
-                  ? const EdgeInsets.symmetric(vertical: 6, horizontal: 0)
+                  ? EdgeInsets.zero
                   : const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
               width: isGrid ? double.infinity : constraints.maxWidth * 0.8,
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(16),
-                border: widget.isSelected
-                    ? Border.all(color: Colors.blueAccent, width: 3)
-                    : null,
                 boxShadow: const [
                   BoxShadow(
                     color: Colors.black26,
@@ -619,28 +616,28 @@ class _ImageTileState extends State<ImageTile> {
                 borderRadius: BorderRadius.circular(16),
                 child: Stack(
                   children: [
-                    if (isGrid)
-                      // Fixed aspect thumbnail in grid mode to ensure a deterministic height
-                      AspectRatio(
-                        aspectRatio: 3 / 4,
-                        child: Image(
-                          image: imageProvider,
-                          fit: BoxFit.cover,
-                          gaplessPlayback: true,
-                          filterQuality: FilterQuality.low,
-                          errorBuilder: (ctx, _, __) =>
-                              const ColoredBox(color: Colors.black12),
-                        ),
-                      )
-                    else
+                    // Fill the tile fully; in grid use cover, in non-grid use contain.
+                    Positioned.fill(
+                      child: Image(
+                        image: imageProvider,
+                        fit: isGrid ? BoxFit.cover : BoxFit.contain,
+                        gaplessPlayback: true,
+                        filterQuality: FilterQuality.low,
+                        errorBuilder: (ctx, _, __) =>
+                            const ColoredBox(color: Colors.black12),
+                      ),
+                    ),
+                    // Selection highlight overlay (does not affect layout size).
+                    if (widget.isSelected)
                       Positioned.fill(
-                        child: Image(
-                          image: imageProvider,
-                          fit: BoxFit.contain,
-                          gaplessPlayback: true,
-                          filterQuality: FilterQuality.low,
-                          errorBuilder: (ctx, _, __) =>
-                              const ColoredBox(color: Colors.black12),
+                        child: IgnorePointer(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(16),
+                              border: Border.all(
+                                  color: Colors.blueAccent, width: 3),
+                            ),
+                          ),
                         ),
                       ),
                     // Top-right: selection icon in selection mode; otherwise the 3-dot menu
@@ -662,8 +659,8 @@ class _ImageTileState extends State<ImageTile> {
                                   decoration: BoxDecoration(
                                     shape: BoxShape.circle,
                                     color: Colors.black.withOpacity(0.55),
-                                    border:
-                                        Border.all(color: Colors.white, width: 2),
+                                    border: Border.all(
+                                        color: Colors.white, width: 2),
                                     boxShadow: const [
                                       BoxShadow(
                                         color: Colors.black26,
@@ -700,8 +697,8 @@ class _ImageTileState extends State<ImageTile> {
                                   decoration: BoxDecoration(
                                     shape: BoxShape.circle,
                                     color: Colors.black.withOpacity(0.55),
-                                    border:
-                                        Border.all(color: Colors.white, width: 2),
+                                    border: Border.all(
+                                        color: Colors.white, width: 2),
                                     boxShadow: const [
                                       BoxShadow(
                                         color: Colors.black26,
@@ -948,6 +945,7 @@ class _ImageTileState extends State<ImageTile> {
                 ),
               ),
             );
+            return isGrid ? AspectRatio(aspectRatio: 3 / 4, child: tile) : tile;
           },
         ),
       ),


### PR DESCRIPTION
Introduce selection mode functionality in the image gallery, allowing users to select multiple images. Address an issue where selecting a tile on the right side caused the next row to reorder unexpectedly.